### PR TITLE
Remove the host variable so the UI can be used on servers other than …

### DIFF
--- a/sleepy/static/site.js
+++ b/sleepy/static/site.js
@@ -1,5 +1,4 @@
 (function() {
-var HOST = "http://localhost:5000";
 var API_PREFIX = "/api/v1/";
 var $resource = $("select[name='resource']");
 
@@ -7,7 +6,7 @@ var $resource = $("select[name='resource']");
 var getUrl = function() {
     var resource = $resource.val();
     var pk = $("#primaryKey").val();
-    var url = HOST + API_PREFIX + resource + "/";
+    var url = API_PREFIX + resource + "/";
     if (pk) {
         url +=  pk;
     };


### PR DESCRIPTION
The ui will silently fail if the user uses anything else than localhost.
E.g. 127.0.0.1, dns name, etc.

The HOST constant was stripped.
